### PR TITLE
Fix Note window left padding with DTM-08

### DIFF
--- a/DTM-08.theme.css
+++ b/DTM-08.theme.css
@@ -136,7 +136,7 @@
 .activity-1ythUs{background:linear-gradient(#272727,#404040 50%,#353535 50%,#383838)}
 .rolesList-22qj2L {max-height: 100px !important;overflow-y: scroll !important;background: linear-gradient(#0008, transparent, #0008) !important;padding: 10px !important}
 .rolesList-22qj2L::-webkit-scrollbar {display: none !important}
-.body-3iLsc4 {padding-left: 0px !important;padding-right: 0px !important}
+.body-3iLsc4 {padding-left: 15px !important;padding-right: 0px !important}
 .body-3iLsc4 .bodyTitle-Y0qMQz {padding-left: 10px !important;padding-right: 10px !important}
 .theme-dark .note-3kmerW textarea {padding-left: 15px !important;padding-right: 15px !important}
 .horizontal-1ae9ci>.flex-1xMQg5:first-child {background: transparent !important}


### PR DESCRIPTION
Was probably broken since Discord's last update, the "Click to add a note" text box is now properly centered/adjusted.