### PR TITLE
DTM-08: Fix authorization box

### DIFF
--- a/DTM-08-V2/dtm-08-v2.scss
+++ b/DTM-08-V2/dtm-08-v2.scss
@@ -8195,7 +8195,7 @@ $exportAddons: false;
   .splashBackground-6P4u0V {
     background: #222
   }
-  .authBoxExpanded_dc6abe, .authBox_dc6abe {
+  .authBoxExpanded_b83a05, .authBox_b83a05 {
     background: linear-gradient(#3F434BDD,#202329DD)!important;
     backdrop-filter: blur(8px);
     border: solid 1px #000;


### PR DESCRIPTION
Fixed after Discord destroyed custom themes.
Before:
![Screenshot 2024-06-25 at 12 06 29 AM](https://github.com/XYZenix/XYZenixThemes/assets/168323856/ce98457a-5ec2-46c9-ae1c-b6994a51c4c8)
After
![Screenshot 2024-06-25 at 12 06 19 AM](https://github.com/XYZenix/XYZenixThemes/assets/168323856/9e637f57-acaa-4606-aafe-9ff903bfad63)
